### PR TITLE
VCST-5163: Stable 15 — GoogleSSO (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.GoogleSSO.Core/VirtoCommerce.GoogleSSO.Core.csproj
+++ b/src/VirtoCommerce.GoogleSSO.Core/VirtoCommerce.GoogleSSO.Core.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.GoogleSSO.Data/VirtoCommerce.GoogleSSO.Data.csproj
+++ b/src/VirtoCommerce.GoogleSSO.Data/VirtoCommerce.GoogleSSO.Data.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.1" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.GoogleSSO.Core\VirtoCommerce.GoogleSSO.Core.csproj" />

--- a/src/VirtoCommerce.GoogleSSO.Web/module.manifest
+++ b/src/VirtoCommerce.GoogleSSO.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1002.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
   </dependencies>
 


### PR DESCRIPTION
Part of **Stable 15** (Wave 1). Builds against the published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) from nuget.org.

- Platform -> **3.1039.0**; module version -> **3.1002.0**.
- `vc-build Compress` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only alignment against published platform packages; risk is mainly if 3.1039 introduces breaking API changes in Platform.Core/Security (mitigated by a green build for this wave).
> 
> **Overview**
> Bumps the Google SSO module to **Virto Commerce platform 3.1039.0** as part of Stable 15 (Wave 1). No application or SSO logic changes.
> 
> **NuGet:** `VirtoCommerce.Platform.Core` and `VirtoCommerce.Platform.Security` move from **3.1002.0** to **3.1039.0** in Core and Data projects.
> 
> **Manifest:** `platformVersion` in `module.manifest` is updated to **3.1039.0**; the module `<version>` remains **3.1002.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d437b6f16e278493e40ac287c4fb0e30af17fb6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.GoogleSSO_3.1002.0-pr-7-d437.zip